### PR TITLE
check enabled and vmx_pt before vmx_pt_get_data_size in topa_full

### DIFF
--- a/arch/x86/kvm/vmx/vmx_pt.c
+++ b/arch/x86/kvm/vmx/vmx_pt.c
@@ -762,7 +762,7 @@ void vmx_pt_vmexit(struct vcpu_vmx_pt *vmx_pt){
 }
 
 bool topa_full(struct vcpu_vmx_pt *vmx_pt){
-	if(vmx_pt_get_data_size(vmx_pt) >= TOPA_MAIN_SIZE){
+	if(enabled && vmx_pt && vmx_pt_get_data_size(vmx_pt) >= TOPA_MAIN_SIZE){
 		return true;
 	}
 	return false;


### PR DESCRIPTION
When ToPA allocation fails, the vmx_pt is NULL. In this case, a BUG: kernel NULL pointer dereference happens.
```
[15920.244363] [KVM-NYX] Error:	Cannot allocate main ToPA buffer!
[15920.244371] [KVM-NYX] Info:	ToPA setup failed...
[15920.299431] BUG: kernel NULL pointer dereference, address: 0000000000000098
[15920.307666] #PF: supervisor read access in kernel mode
[15920.315782] #PF: error_code(0x0000) - not-present page
[15920.323793] PGD 0 P4D 0 
[15920.331649] Oops: 0000 [#1] SMP NOPTI
[15920.339392] CPU: 8 PID: 69749 Comm: qemu-system-x86 Kdump: loaded Tainted: G           OE     5.10.75-051075-generic #202110201038
[15920.354858] Hardware name: Supermicro Super Server/X11DPL-i, BIOS 3.8b 01/05/2023
[15920.362553] RIP: 0010:topa_full+0x6/0x60 [kvm_intel]
[15920.370126] Code: 0f 1f 40 00 5b 41 5c 5d c3 65 8b 15 64 34 82 3f 48 c7 c7 47 cd 7f c0 e8 b1 dd 1d db eb 8f 66 0f 1f 44 00 00 0f 1f 44 00 00 55 <48> 8b 87 98 00 00 00 48 89 e5 a9 80 ff ff ff 75 19 48 c1 e8 20 48
[15920.385346] RSP: 0018:ffffb3b9e240bd48 EFLAGS: 00010046
[15920.392820] RAX: 0000000000000000 RBX: ffff991ea03f0000 RCX: ffff9933017b51c0
[15920.400249] RDX: ffff9933017b51c0 RSI: 00000000ffff0ff0 RDI: 0000000000000000
[15920.407575] RBP: ffffb3b9e240bd90 R08: 0000000000000004 R09: 0000000000000794
[15920.414796] R10: 0000000000000000 R11: ffffb3b9e240bcc0 R12: ffff991ea03f0000
[15920.421922] R13: 0000000000000000 R14: 00000000ffffffff R15: ffff991ea03f0038
[15920.428924] FS:  00007fe89d478640(0000) GS:ffff99323fa00000(0000) knlGS:0000000000000000
[15920.435850] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[15920.442667] CR2: 0000000000000098 CR3: 00000012e0e04006 CR4: 00000000007726e0
[15920.449438] PKRU: 55555554
[15920.456040] Call Trace:
[15920.462512]  ? vmx_vcpu_run+0x38/0xed0 [kvm_intel]
[15920.468897]  ? vmx_prepare_switch_to_guest+0x143/0x1a0 [kvm_intel]
[15920.475258]  kvm_arch_vcpu_ioctl_run+0xa85/0x1720 [kvm]
[15920.481477]  kvm_vcpu_ioctl+0x247/0x5f0 [kvm]
[15920.487557]  ? do_futex+0x16a/0x1f0
[15920.493492]  __x64_sys_ioctl+0x91/0xc0
[15920.499304]  do_syscall_64+0x38/0x90
[15920.504979]  entry_SYSCALL_64_after_hwframe+0x44/0xa9
[15920.510590] RIP: 0033:0x7fe89f92794f
[15920.516077] Code: 00 48 89 44 24 18 31 c0 48 8d 44 24 60 c7 04 24 10 00 00 00 48 89 44 24 08 48 8d 44 24 20 48 89 44 24 10 b8 10 00 00 00 0f 05 <41> 89 c0 3d 00 f0 ff ff 77 1f 48 8b 44 24 18 64 48 2b 04 25 28 00
[15920.527111] RSP: 002b:00007fe89d477460 EFLAGS: 00000246 ORIG_RAX: 0000000000000010
[15920.532536] RAX: ffffffffffffffda RBX: 000000000000ae80 RCX: 00007fe89f92794f
[15920.537890] RDX: 0000000000000000 RSI: 000000000000ae80 RDI: 000000000000000b
[15920.543106] RBP: 000056426352c8e0 R08: 0000564260e69f50 R09: 0000000000000000
[15920.548217] R10: 0000000000000000 R11: 0000000000000246 R12: 0000000000000000
[15920.553194] R13: 0000000000000007 R14: 00007fe89f8a17d0 R15: 00007ffda8670e30
[15920.558062] Modules linked in: xt_conntrack nft_chain_nat xt_MASQUERADE nf_conntrack_netlink xfrm_user xfrm_algo nft_counter xt_addrtype nft_compat nf_tables nfnetlink br_netfilter bridge stp llc overlay rpcrdma sunrpc rdma_ucm ib_iser libiscsi scsi_transport_iscsi rdma_cm ib_cm iw_cm binfmt_misc intel_rapl_msr intel_rapl_common isst_if_common skx_edac nfit x86_pkg_temp_thermal intel_powerclamp coretemp kvm_intel(OE) kvm(OE) nls_iso8859_1 ipmi_ssif crct10dif_pclmul ghash_clmulni_intel aesni_intel crypto_simd cryptd glue_helper rapl intel_cstate drm_vram_helper drm_ttm_helper ttm i40iw drm_kms_helper ib_uverbs cec rc_core ib_core input_leds joydev i2c_algo_bit fb_sys_fops syscopyarea sysfillrect sysimgblt mei_me mei ioatdma dca acpi_ipmi ipmi_si ipmi_devintf ipmi_msghandler acpi_pad acpi_power_meter mac_hid sch_fq_codel openvswitch nsh nf_conncount nf_nat nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 libcrc32c parport_pc ppdev lp drm parport efi_pstore ip_tables x_tables autofs4 hid_generic
[15920.558155]  usbhid hid crc32_pclmul i40e megaraid_sas i2c_i801 ahci xhci_pci lpc_ich i2c_smbus libahci xhci_pci_renesas
[15920.602287] CR2: 0000000000000098
```